### PR TITLE
Without Main, Module can't be found

### DIFF
--- a/src/lazymod.jl
+++ b/src/lazymod.jl
@@ -4,7 +4,7 @@ function lazymod(mod)
   quote
     function $(symbol(lowercase(string(mod))))()
       require($(string(mod)))
-      $mod
+      Main.$mod
     end
   end |> esc
 end


### PR DESCRIPTION
Also, shouldn't you use gensym() for the function name and then return the load function? This will reduce naming conflicts, and the syntax will be changed to an acceptable:
```Julia
imagesload = @lazymod Images
```