### PR TITLE
changed require to eval import

### DIFF
--- a/src/lazymod.jl
+++ b/src/lazymod.jl
@@ -3,7 +3,7 @@ export @lazymod
 function lazymod(mod)
   quote
     function $(symbol(lowercase(string(mod))))()
-      require($(string(mod)))
+      @eval import $mod
       Main.$mod
     end
   end |> esc


### PR DESCRIPTION
This gets rid of a 0.4 deprecation warning for me... does it create any problems that I don't foresee?